### PR TITLE
Add celerybeat autodiscovery to cronitor-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,36 @@ def send_invoices_task(*args, **kwargs):
 
 The `@cronitor.job` is a lightweight way to monitor background tasks run with libraries like Celery's [Beat Scheduler](https://docs.celeryproject.org/en/v5.0.5/reference/celery.beat.html) or the popular [schedule](https://github.com/dbader/schedule) package.
 
-#### celery example
+#### celerybeat autodiscover example
+`cronitor-python` can automatically discover all of your declared celerybeat scheduled tasks,
+creating Cronitor monitors for them and sending pings when tasks run, succeed, or fail.
+
+> Note: tasks on [solar schedules](https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html#solar-schedules) are not supported and will be ignored.
+
+```python
+import cronitor.celery
+from celery import Celery
+
+app = Celery()
+cronitor.celery.initialize(app, api_key='apiKey123')
+# Alternatively, can set cronitor.api_key directly:
+import cronitor
+cronitor.api_key = 'apiKey123'
+cronitor.celery.initialize(app)
+
+app.conf.beat_schedule = {
+    'run-me-every-minute': {
+        'task': 'tasks.every_minute_celery_task',
+        'schedule': 60
+    }
+}
+
+@app.task
+def every_minute_celery_task():
+    print("running a background job with celery...")
+```
+
+#### manual celery example
 ```python
 import cronitor
 from celery import Celery

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ def send_invoices_task(*args, **kwargs):
 
 The `@cronitor.job` is a lightweight way to monitor background tasks run with libraries like Celery's [Beat Scheduler](https://docs.celeryproject.org/en/v5.0.5/reference/celery.beat.html) or the popular [schedule](https://github.com/dbader/schedule) package.
 
-#### celerybeat autodiscover example
-`cronitor-python` can automatically discover all of your declared celerybeat scheduled tasks,
+#### celery autodiscover example
+`cronitor-python` can automatically discover all of your declared celery tasks, including your celerybeat scheduled tasks,
 creating Cronitor monitors for them and sending pings when tasks run, succeed, or fail.
 
-Requires Celery 4.0 or higher. celerybeat autodiscover utilizes the Celery [message protocol version 2](https://docs.celeryproject.org/en/stable/internals/protocol.html#version-2).
+Requires Celery 4.0 or higher. celery autodiscover utilizes the Celery [message protocol version 2](https://docs.celeryproject.org/en/stable/internals/protocol.html#version-2).
 
 > Note: tasks on [solar schedules](https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html#solar-schedules) are not supported and will be ignored.
 
@@ -68,6 +68,16 @@ app.conf.beat_schedule = {
 @app.task
 def every_minute_celery_task():
     print("running a background job with celery...")
+
+@app.task
+def this_task_triggered_manually():
+    print("Even though I'm not on a schedule, I'll still be monitored!")
+```
+
+If you want only to monitor celerybeat periodic tasks, and not tasks triggered any other way, you can set `celereybeat_only=True` when initializing:
+```python
+app = Celery()
+cronitor.celery.initialize(app, celerybeat_only=True)
 ```
 
 #### manual celery example

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The `@cronitor.job` is a lightweight way to monitor background tasks run with li
 `cronitor-python` can automatically discover all of your declared celerybeat scheduled tasks,
 creating Cronitor monitors for them and sending pings when tasks run, succeed, or fail.
 
+Requires Celery 4.0 or higher. celerybeat autodiscover utilizes the Celery [message protocol version 2](https://docs.celeryproject.org/en/stable/internals/protocol.html#version-2).
+
 > Note: tasks on [solar schedules](https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html#solar-schedules) are not supported and will be ignored.
 
 ```python
@@ -52,9 +54,9 @@ from celery import Celery
 app = Celery()
 cronitor.celery.initialize(app, api_key='apiKey123')
 # Alternatively, can set cronitor.api_key directly:
-import cronitor
-cronitor.api_key = 'apiKey123'
-cronitor.celery.initialize(app)
+# import cronitor
+# cronitor.api_key = 'apiKey123'
+# cronitor.celery.initialize(app)
 
 app.conf.beat_schedule = {
     'run-me-every-minute': {

--- a/cronitor/__init__.py
+++ b/cronitor/__init__.py
@@ -26,6 +26,7 @@ api_key = os.getenv('CRONITOR_API_KEY', None)
 api_version = os.getenv('CRONITOR_API_VERSION', None)
 environment = os.getenv('CRONITOR_ENVIRONMENT', None)
 config = os.getenv('CRONITOR_CONFIG', None)
+celerybeat_only = False
 
 # this is a pointer to the module object instance itself.
 this = sys.modules[__name__]

--- a/cronitor/celery.py
+++ b/cronitor/celery.py
@@ -58,7 +58,7 @@ def initialize(app, api_key=None):  # type: (celery.Celery, Optional[str]) -> No
             entry = schedules[name]  # type: celery.beat.ScheduleEntry
 
             # ignore all celerybeat scheduled events with the Cronitor exclusion header
-            headers = entry.options.get('headers', {})
+            headers = entry.options.pop('headers', {})
             if headers.get('x-cronitor-exclude') in (True, 'true', 'True'):
                 logger.info("celerybeat entry '{}' ignored per exclusion header".format(name))
                 continue
@@ -97,7 +97,7 @@ def initialize(app, api_key=None):  # type: (celery.Celery, Optional[str]) -> No
                                   # works better then in periodic task options
                                   app.tasks.get(entry.task).s().set(headers=headers),
                                   args=entry.args, kwargs=entry.kwargs,
-                                  name=entry.name)
+                                  name=entry.name, **(entry.options or {}))
 
         # app.conf.beat_schedule = app.conf.changes['beat_schedule']
         # To avoid recursion, since restarting celerybeat will result in this

--- a/cronitor/celery.py
+++ b/cronitor/celery.py
@@ -1,0 +1,148 @@
+import typing
+import datetime
+import humanize
+import logging
+from cronitor import State, Monitor
+import cronitor
+import sys
+
+logger = logging.getLogger(__name__)
+try:
+    import celery
+    import celery.beat
+    from celery.schedules import crontab, schedule, solar
+    from celery.signals import beat_init, task_prerun, task_failure, task_success, task_retry
+
+    if typing.TYPE_CHECKING:
+        from typing import Dict, List, Union, Optional
+        import billiard.einfo
+        from celery.worker.request import Request
+except ImportError:
+    logger.error("Cannot use the cronitor.celery module without celery installed")
+    sys.exit(1)
+
+# For the signals to properly register, they need to be top-level objects.
+# Since they are defined dynamically in initialize(), we have to declare them up top,
+# make them global, and override them.
+celerybeat_startup = None
+ping_monitor_before_task = None
+ping_monitor_on_success = None
+ping_monitor_on_failure = None
+ping_monitor_on_retry = None
+
+
+def get_headers_from_task(task):  # type: (celery.Task) -> Dict
+    headers = task.request.headers or {}
+    headers.update(task.request.properties.get('application_headers', {}))
+    return headers
+
+
+def initialize(app, api_key=None):  # type: (celery.Celery, Optional[str]) -> None
+    if api_key:
+        cronitor.api_key = api_key
+
+    global celerybeat_startup
+    global ping_monitor_before_task
+    global ping_monitor_on_success
+    global ping_monitor_on_failure
+    global ping_monitor_on_retry
+
+    def celerybeat_startup(sender, **kwargs):  # type: (celery.beat.Service, Dict) -> None
+        scheduler = sender.get_scheduler()  # type: celery.beat.Scheduler
+        schedules = scheduler.get_schedule()
+        monitors = []  # type: List[Dict[str, str]]
+
+        for name in schedules:
+            if name.startswith('celery.'):
+                continue
+            entry = schedules[name]  # type: celery.beat.ScheduleEntry
+
+            # ignore all celerybeat scheduled events with the Cronitor exclusion header
+            headers = entry.options.get('headers', {})
+            if headers.get('x-cronitor-exclude') in (True, 'true', 'True'):
+                logger.info("celerybeat entry '{}' ignored per exclusion header".format(name))
+                continue
+
+            item = entry.schedule  # type: celery.schedules.schedule
+            if isinstance(item, crontab):
+                cronitor_schedule = ('{0._orig_minute} {0._orig_hour} {0._orig_day_of_week} {0._orig_day_of_month} '
+                                     '{0._orig_month_of_year}').format(item)
+            elif isinstance(item, schedule):
+                freq = item.run_every  # type: datetime.timedelta
+                cronitor_schedule = 'every ' + humanize.precisedelta(freq)
+            elif isinstance(item, solar):
+                # We don't support solar schedules
+                logger.warning("The cronitor-python celery module does not support "
+                               "tasks using solar schedules. Task schedule '{}' will "
+                               "not be monitored".format(name))
+                continue
+            else:
+                logger.warning("The cronitor-python celery module does not support "
+                               "schedules of type `{}`".format(type(item)))
+                continue
+
+            monitors.append({
+                'type': 'job',
+                'key': name,
+                'schedule': cronitor_schedule,
+            })
+
+            headers.update({
+                'x-cronitor-task-origin': 'celerybeat',
+                'x-cronitor-celerybeat-name': name,
+            })
+
+            app.add_periodic_task(entry.schedule,
+                                  # Setting headers in the signature
+                                  # works better then in periodic task options
+                                  app.tasks.get(entry.task).s().set(headers=headers),
+                                  args=entry.args, kwargs=entry.kwargs,
+                                  name=entry.name)
+
+        # app.conf.beat_schedule = app.conf.changes['beat_schedule']
+        # To avoid recursion, since restarting celerybeat will result in this
+        # signal being called again, we disconnect the signal.
+        beat_init.disconnect(celerybeat_startup, dispatch_uid=1)
+
+        # We need to stop and restart celerybeat to get the task updates in place.
+        # This isn't ideal, but seems to work.
+        sender.stop()
+        app.Beat().run()
+        logger.debug("Creating Cronitor monitors: %s", [m['key'] for m in monitors])
+        Monitor.put(monitors)
+
+    beat_init.connect(celerybeat_startup, dispatch_uid=1)
+
+    @task_prerun.connect
+    def ping_monitor_before_task(sender, **kwargs):  # type: (celery.Task, Dict) -> None
+        headers = get_headers_from_task(sender)
+        if 'x-cronitor-celerybeat-name' in headers:
+            monitor = Monitor(headers['x-cronitor-celerybeat-name'])
+            monitor.ping(state=State.RUN, series=sender.request.id)
+
+    @task_success.connect
+    def ping_monitor_on_success(sender, **kwargs):  # type: (celery.Task, Dict) -> None
+        headers = get_headers_from_task(sender)
+        if 'x-cronitor-celerybeat-name' in headers:
+            monitor = Monitor(headers['x-cronitor-celerybeat-name'])
+            monitor.ping(state=State.COMPLETE, series=sender.request.id)
+
+    @task_failure.connect
+    def ping_monitor_on_failure(sender, **kwargs):  # type: (celery.Task, Dict) -> None
+        headers = get_headers_from_task(sender)
+        if 'x-cronitor-celerybeat-name' in headers:
+            monitor = Monitor(headers['x-cronitor-celerybeat-name'])
+            monitor.ping(state=State.FAIL, series=sender.request.id)
+
+    @task_retry.connect
+    def ping_monitor_on_retry(sender,  # type: celery.Task
+                              request,  # type: celery.worker.request.Request
+                              reason,  # type: Union[Exception, str]
+                              einfo,  # type: billiard.einfo.ExceptionInfo
+                              **kwargs,  # type: Dict
+                              ):
+        headers = get_headers_from_task(sender)
+        if 'x-cronitor-celerybeat-name' in headers:
+            monitor = Monitor(headers['x-cronitor-celerybeat-name'])
+            monitor.ping(state=State.FAIL, series=sender.request.id, message=str(reason))
+

--- a/cronitor/celery.py
+++ b/cronitor/celery.py
@@ -99,7 +99,6 @@ def initialize(app, api_key=None):  # type: (celery.Celery, Optional[str]) -> No
                                   args=entry.args, kwargs=entry.kwargs,
                                   name=entry.name, **(entry.options or {}))
 
-        # app.conf.beat_schedule = app.conf.changes['beat_schedule']
         # To avoid recursion, since restarting celerybeat will result in this
         # signal being called again, we disconnect the signal.
         beat_init.disconnect(celerybeat_startup, dispatch_uid=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.24.0
 pyyaml==5.4
+humanize==3.13.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cronitor',
-    version='4.3.0',
+    version='4.3.1',
     packages=find_packages(),
     url='https://github.com/cronitorio/cronitor-python',
     license='MIT License',
@@ -11,7 +11,8 @@ setup(
     description='A lightweight Python client for Cronitor.',
     install_requires=[
         'requests',
-        'pyyaml'
+        'pyyaml',
+        'humanize',
     ],
     entry_points=dict(console_scripts=['cronitor = cronitor.__main__:main'])
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cronitor',
-    version='4.3.1',
+    version='4.4.0',
     packages=find_packages(),
     url='https://github.com/cronitorio/cronitor-python',
     license='MIT License',


### PR DESCRIPTION
Adds autodiscovery for celerybeat to `cronitor-python`.  When used, the package will automatically create or update monitors for all declared celerybeat schedules and send telemetry events when tasks run, succeed, or fail.

Currently tested with Celery 5.x.

This should be considered beta and requires testing with users with various configurations.