### PR TITLE
Add diff_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ cronitor.validate_config() # send monitors to Cronitor for configuration validat
 cronitor.apply_config() # sync the monitors from the config file to Cronitor
 
 cronitor.generate_config() # generate a new config file from the Cronitor API
+
+cronitor.diff_config('./cronitor.yaml') # compare the config file to the monitors currently configured in Cronitor
 ```
 
 


### PR DESCRIPTION
I used open source dyff and deep diff to set up CI. However, I thought it would be useful to have DIFF in the library, so I made it.

The following is a sample output.
```bash
$ python diff.py
Target : hoge(foo)
Remote : -     schedule: 55 10-21 * * THU
Diff   : ?                            ^^^

Local  : +     schedule: 55 10-21 * * 4
Diff   : ?                            ^

Target : hoge(foo)
Local  : +     paused: true

Target : hoge(foo)
Local  : +     schedule: 0/10 10-22 * * 1,2,3,4,6,7
Remote : -     schedule: 0/10 10-22 * * SUN-WED,FRI-SAT
Remote : -     timezone: Asia/Tokyo
Remote : -   hogeee:
Remote : -     environments:
Remote : -     - production
Remote : -     grace_seconds: 180
Remote : -     group: hogeee
Remote : -     name: hogeee
Remote : -     notify:
Remote : -     - dev
Remote : -     platform: linux cron
Remote : -     realert_interval: every 8 hours
Remote : -     schedule: '*/10 0-21,23 * * 4'

Target : hoge(foo)
Local  : +     timezone: Asia/Tokyo
Local  : +   hoge-fix_1:
Local  : +     environments:
Local  : +     - production
Local  : +     grace_seconds: 180
Local  : +     group: tako
Local  : +     name: hoge
Local  : +     notify:
Local  : +     - dev
Local  : +     platform: linux cron
Local  : +     realert_interval: every 8 hours
Local  : +     schedule: 0/10 10-22 * * 1,2,3,4,6,7
```