### PR TITLE
Allow *_config timeout to be specified as an env var/args.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,21 @@ cronitor.api_key = 'apiKey123'
 
 cronitor.read_config('./cronitor.yaml') # parse the yaml file of monitors
 
-cronitor.validate_config() # send monitors to Cronitor for configuration validation, Timeout from CRONITOR_TIMEOUT env var or arg; CRONITOR_TIMEOUT takes priority.
+cronitor.validate_config() # send monitors to Cronitor for configuration validation.
 
-cronitor.apply_config() # sync the monitors from the config file to Cronitor, Timeout from CRONITOR_TIMEOUT env var or arg; CRONITOR_TIMEOUT takes priority.
+cronitor.apply_config() # sync the monitors from the config file to Cronitor.
 
-cronitor.generate_config() # generate a new config file from the Cronitor API, Timeout from CRONITOR_TIMEOUT env var or arg; CRONITOR_TIMEOUT takes priority.
+cronitor.generate_config() # generate a new config file from the Cronitor API.
 ```
 
+The timeout value for validate_config, apply_config and generate_config is 10 seconds by default. The value can be rewritten by setting the environment variable `CRONITOR_TIMEOUT`. It can also be rewritten by assigning a value to cronitor.timeout.
+
+```python
+import cronitor
+
+cronitor.timeout = 30
+cronitor.apply_config()
+```
 
 The `cronitor.yaml` file includes three top level keys `jobs`, `checks`, `heartbeats`. You can configure monitors under each key by defining [monitors](https://cronitor.io/docs/monitor-api#attributes).
 

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ cronitor.api_key = 'apiKey123'
 
 cronitor.read_config('./cronitor.yaml') # parse the yaml file of monitors
 
-cronitor.validate_config() # send monitors to Cronitor for configuration validation.
+cronitor.validate_config() # send monitors to Cronitor for configuration validation
 
-cronitor.apply_config() # sync the monitors from the config file to Cronitor.
+cronitor.apply_config() # sync the monitors from the config file to Cronitor
 
-cronitor.generate_config() # generate a new config file from the Cronitor API.
+cronitor.generate_config() # generate a new config file from the Cronitor API
 ```
 
 The timeout value for validate_config, apply_config and generate_config is 10 seconds by default. The value can be rewritten by setting the environment variable `CRONITOR_TIMEOUT`. It can also be rewritten by assigning a value to cronitor.timeout.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ app.conf.beat_schedule = {
     }
 }
 
-# Discover all of your celery tasks and automatically add monitoring. 
+# Discover all of your celery tasks and automatically add monitoring.
 cronitor.celery.initialize(app, api_key="apiKey123")
 
 @app.task
@@ -76,7 +76,7 @@ cronitor.api_key = 'apiKey123'
 
 # Apply the cronitor decorator to monitor any function.
 # If no monitor matches the provided key, one will be created automatically.
-@cronitor.job('send-invoices') 
+@cronitor.job('send-invoices')
 def send_invoices_task(*args, **kwargs):
     ...
 ```
@@ -124,11 +124,11 @@ cronitor.api_key = 'apiKey123'
 
 cronitor.read_config('./cronitor.yaml') # parse the yaml file of monitors
 
-cronitor.validate_config() # send monitors to Cronitor for configuration validation
+cronitor.validate_config() # send monitors to Cronitor for configuration validation, Timeout from CRONITOR_TIMEOUT env var or arg; CRONITOR_TIMEOUT takes priority.
 
-cronitor.apply_config() # sync the monitors from the config file to Cronitor
+cronitor.apply_config() # sync the monitors from the config file to Cronitor, Timeout from CRONITOR_TIMEOUT env var or arg; CRONITOR_TIMEOUT takes priority.
 
-cronitor.generate_config() # generate a new config file from the Cronitor API
+cronitor.generate_config() # generate a new config file from the Cronitor API, Timeout from CRONITOR_TIMEOUT env var or arg; CRONITOR_TIMEOUT takes priority.
 ```
 
 

--- a/cronitor/__init__.py
+++ b/cronitor/__init__.py
@@ -17,6 +17,13 @@ api_key = os.getenv('CRONITOR_API_KEY', None)
 api_version = os.getenv('CRONITOR_API_VERSION', None)
 environment = os.getenv('CRONITOR_ENVIRONMENT', None)
 config = os.getenv('CRONITOR_CONFIG', None)
+timeout = os.getenv('CRONITOR_TIMEOUT', None)
+if timeout is not None:
+    timeout = int(timeout)
+    cronitor_timeout = timeout
+else:
+    cronitor_timeout = None
+
 celerybeat_only = False
 
 # this is a pointer to the module object instance itself.
@@ -70,21 +77,24 @@ def job(key, env=None, log_output=True, include_output=True):
         return wrapped
     return wrapper
 
-def generate_config():
+def generate_config(timeout=10):
+    timeout = cronitor_timeout or timeout
     config = this.config or './cronitor.yaml'
     with open(config, 'w') as conf:
-        conf.writelines(Monitor.as_yaml())
+        conf.writelines(Monitor.as_yaml(timeout=timeout))
 
-def validate_config():
-    return apply_config(rollback=True)
+def validate_config(timeout=10):
+    timeout = cronitor_timeout or timeout
+    return apply_config(rollback=True, timeout=timeout)
 
-def apply_config(rollback=False):
+def apply_config(rollback=False, timeout=10):
+    timeout = cronitor_timeout or timeout
     if not this.config:
         raise ConfigValidationError("Must set a path to config file e.g. cronitor.config = './cronitor.yaml'")
 
     config = read_config(output=True)
     try:
-        monitors = Monitor.put(monitors=config, rollback=rollback, format=YAML)
+        monitors = Monitor.put(monitors=config, timeout=timeout, rollback=rollback, format=YAML)
         job_count = len(monitors.get('jobs', []))
         check_count = len(monitors.get('checks', []))
         heartbeat_count = len(monitors.get('heartbeats', []))

--- a/cronitor/__init__.py
+++ b/cronitor/__init__.py
@@ -20,9 +20,6 @@ config = os.getenv('CRONITOR_CONFIG', None)
 timeout = os.getenv('CRONITOR_TIMEOUT', None)
 if timeout is not None:
     timeout = int(timeout)
-    cronitor_timeout = timeout
-else:
-    cronitor_timeout = None
 
 celerybeat_only = False
 
@@ -77,24 +74,21 @@ def job(key, env=None, log_output=True, include_output=True):
         return wrapped
     return wrapper
 
-def generate_config(timeout=10):
-    timeout = cronitor_timeout or timeout
+def generate_config():
     config = this.config or './cronitor.yaml'
     with open(config, 'w') as conf:
-        conf.writelines(Monitor.as_yaml(timeout=timeout))
+        conf.writelines(Monitor.as_yaml())
 
-def validate_config(timeout=10):
-    timeout = cronitor_timeout or timeout
-    return apply_config(rollback=True, timeout=timeout)
+def validate_config():
+    return apply_config(rollback=True)
 
-def apply_config(rollback=False, timeout=10):
-    timeout = cronitor_timeout or timeout
+def apply_config(rollback=False):
     if not this.config:
         raise ConfigValidationError("Must set a path to config file e.g. cronitor.config = './cronitor.yaml'")
 
     config = read_config(output=True)
     try:
-        monitors = Monitor.put(monitors=config, timeout=timeout, rollback=rollback, format=YAML)
+        monitors = Monitor.put(monitors=config, rollback=rollback, format=YAML)
         job_count = len(monitors.get('jobs', []))
         check_count = len(monitors.get('checks', []))
         heartbeat_count = len(monitors.get('heartbeats', []))

--- a/cronitor/monitor.py
+++ b/cronitor/monitor.py
@@ -38,8 +38,8 @@ class Monitor(object):
     _req = retry_session(retries=3)
 
     @classmethod
-    def as_yaml(cls, api_key=None, api_version=None, timeout=10):
-        timeout = cronitor.timeout or timeout
+    def as_yaml(cls, api_key=None, api_version=None):
+        timeout = cronitor.timeout or 10
         api_key = api_key or cronitor.api_key
         resp = cls._req.get('%s.yaml' % cls._monitor_api_url(),
                         auth=(api_key, ''),
@@ -55,7 +55,6 @@ class Monitor(object):
         api_key = cronitor.api_key
         api_version = cronitor.api_version
         request_format = JSON
-        timeout = 10
 
         rollback = False
         if 'rollback' in kwargs:
@@ -70,16 +69,11 @@ class Monitor(object):
         if 'format' in kwargs:
             request_format = kwargs['format']
             del kwargs['format']
-        if 'timeout' in kwargs:
-            timeout = kwargs['timeout']
-            del kwargs['timeout']
-
-        timeout = cronitor.timeout or timeout
 
         _monitors = monitors or [kwargs]
         nested_format = True if type(monitors) == dict else False
 
-        data = cls._put(_monitors, api_key, rollback, request_format, api_version, timeout)
+        data = cls._put(_monitors, api_key, rollback, request_format, api_version)
 
         if nested_format:
             return data
@@ -93,7 +87,8 @@ class Monitor(object):
         return _monitors if len(_monitors) > 1 else _monitors[0]
 
     @classmethod
-    def _put(cls, monitors, api_key, rollback, request_format, api_version, timeout):
+    def _put(cls, monitors, api_key, rollback, request_format, api_version):
+        timeout = cronitor.timeout or 10
         payload = _prepare_payload(monitors, rollback, request_format)
         if request_format == YAML:
             content_type = 'application/yaml'

--- a/cronitor/tests/test_config.py
+++ b/cronitor/tests/test_config.py
@@ -9,7 +9,7 @@ FAKE_API_KEY = 'cb54ac4fd16142469f2d84fc1bbebd84XXXDEADXXX'
 YAML_PATH = './cronitor/tests/cronitor.yaml'
 
 cronitor.api_key = FAKE_API_KEY
-timeout = cronitor.timeout or 10
+cronitor.timeout = 10
 
 with open(YAML_PATH, 'r') as conf:
     YAML_DATA = yaml.safe_load(conf)
@@ -29,10 +29,10 @@ class CronitorTests(unittest.TestCase):
     def test_validate_config(self, mock):
             cronitor.config = YAML_PATH
             cronitor.validate_config()
-            mock.assert_called_once_with(monitors=YAML_DATA, timeout=timeout, rollback=True, format='yaml')
+            mock.assert_called_once_with(monitors=YAML_DATA, rollback=True, format='yaml')
 
     @patch('cronitor.Monitor.put')
     def test_apply_config(self, mock):
         cronitor.config = YAML_PATH
         cronitor.apply_config()
-        mock.assert_called_once_with(monitors=YAML_DATA, timeout=timeout, rollback=False, format='yaml')
+        mock.assert_called_once_with(monitors=YAML_DATA, rollback=False, format='yaml')

--- a/cronitor/tests/test_config.py
+++ b/cronitor/tests/test_config.py
@@ -9,6 +9,7 @@ FAKE_API_KEY = 'cb54ac4fd16142469f2d84fc1bbebd84XXXDEADXXX'
 YAML_PATH = './cronitor/tests/cronitor.yaml'
 
 cronitor.api_key = FAKE_API_KEY
+timeout = cronitor.timeout or 10
 
 with open(YAML_PATH, 'r') as conf:
     YAML_DATA = yaml.safe_load(conf)
@@ -28,10 +29,10 @@ class CronitorTests(unittest.TestCase):
     def test_validate_config(self, mock):
             cronitor.config = YAML_PATH
             cronitor.validate_config()
-            mock.assert_called_once_with(monitors=YAML_DATA, rollback=True, format='yaml')
+            mock.assert_called_once_with(monitors=YAML_DATA, timeout=timeout, rollback=True, format='yaml')
 
     @patch('cronitor.Monitor.put')
     def test_apply_config(self, mock):
         cronitor.config = YAML_PATH
         cronitor.apply_config()
-        mock.assert_called_once_with(monitors=YAML_DATA, rollback=False, format='yaml')
+        mock.assert_called_once_with(monitors=YAML_DATA, timeout=timeout, rollback=False, format='yaml')


### PR DESCRIPTION
@aflanagan  @shaneharter

If the number of monitors exceeds 150, the following error occurs in validate_config and apply_config.
```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='cronitor.io', port=443): Max retries exceeded with url: /api/monitors.yaml (Caused by ReadTimeoutError("HTTPSConnectionPool(host='cronitor.io', port=443): Read timed out. (read timeout=10)"))
```
The timeout value is fixed to 10 seconds inside the library and we wanted to be able to set it with env var/args.
