### PR TITLE
update pyyaml 5.4->6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.24.0
-pyyaml==5.4
+pyyaml==6.0.1
 humanize==3.13.1


### PR DESCRIPTION
With the release of Cython3, the [test workflow now terminates abnormally(py version 3.10 or 3.11)](https://github.com/yjszk/cronitor-python/actions/runs/6054950502). 
This issue is detailed.
https://github.com/yaml/pyyaml/issues/724
Downgrading pyyaml to 5.3.1 or updating to 6.0.1 seems to solve it.
So, I updated to 6.0.1 latest.

[test result](https://github.com/yjszk/cronitor-python/actions/runs/6055842980)
