### PR TITLE
only allow setting cronitor attributes on module

### DIFF
--- a/cronitor/__init__.py
+++ b/cronitor/__init__.py
@@ -17,9 +17,7 @@ api_key = os.getenv('CRONITOR_API_KEY', None)
 api_version = os.getenv('CRONITOR_API_VERSION', None)
 environment = os.getenv('CRONITOR_ENVIRONMENT', None)
 config = os.getenv('CRONITOR_CONFIG', None)
-timeout = os.getenv('CRONITOR_TIMEOUT', None)
-if timeout is not None:
-    timeout = int(timeout)
+timeout = int(os.getenv('CRONITOR_TIMEOUT', 10))
 
 celerybeat_only = False
 


### PR DESCRIPTION
Simplify the interface for the PUT/YAML methods by only reading attrs that are set on the `cronitor` module

 - api_key
 - api_version
 - env
 - timeout